### PR TITLE
feat: add NotFair (open-source Claude Code skills for SEO and paid ads)

### DIFF
--- a/data/notfair.yaml
+++ b/data/notfair.yaml
@@ -1,0 +1,4 @@
+name: NotFair
+link: https://github.com/nowork-studio/NotFair
+creator: nowork-studio
+kind: Develop Tool


### PR DESCRIPTION
Hi, thanks for maintaining this list!

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)** — an open-source set of Claude Code agent skills focused on SEO, GEO, Google Ads, and Meta Ads. It connects to live marketing data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. It has around ~2.9k stars on GitHub.

It fits the "Develop Tool" category since it's a developer-facing Claude Code plugin that extends the AI coding assistant with marketing capabilities.

Happy to adjust the wording, category, or format to better match the list's conventions.