### PR TITLE
Add Auferet (memory-first AI game master)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Collection of the awesome AI tools:
 | Name | Creator |
 |---|---|
 | [ChatGLM](https://chatglm.cn/) | Unknown |
-[Auferet](https://auferet.com) - AI game master with persistent memory for your characters and uploaded lore; solo or multiplayer, with 5e and Pathfinder 2e modes.
+| [Auferet](https://auferet.com) | AI game master that remembers your world: persistent memory for characters, places, and lore you upload; solo or multiplayer, 5e & Pathfinder 2e |
 | [ChatGPT](https://chat.openai.com/) | OpenAI |
 | [海螺 AI](https://hailuoai.com/) | Unknown |
 | [Kimi](https://kimi.moonshot.cn/) |  |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Collection of the awesome AI tools:
 | Name | Creator |
 |---|---|
 | [ChatGLM](https://chatglm.cn/) | Unknown |
+[Auferet](https://auferet.com) - AI game master with persistent memory for your characters and uploaded lore; solo or multiplayer, with 5e and Pathfinder 2e modes.
 | [ChatGPT](https://chat.openai.com/) | OpenAI |
 | [海螺 AI](https://hailuoai.com/) | Unknown |
 | [Kimi](https://kimi.moonshot.cn/) |  |


### PR DESCRIPTION
Adds Auferet, an AI game master for solo and multiplayer roleplaying games. It keeps your characters, world, and events in persistent memory and reads lore you upload, so the story stays consistent across long campaigns. Runs 5e and Pathfinder 2e, plays in the browser and on Android, free to start.

Website: https://auferet.com
