### PR TITLE
Add OpenAgentRelay

### DIFF
--- a/data/open-agent-relay.yaml
+++ b/data/open-agent-relay.yaml
@@ -1,0 +1,3 @@
+name: OpenAgentRelay
+link: https://github.com/ShakespeareLabs/open-agent-relay
+kind: Develop Tool


### PR DESCRIPTION
Adds OpenAgentRelay through the repository's YAML data source under Develop Tool. OpenAgentRelay is an Apache-2.0 Python CLI for making an existing local agent or automation callable by teammates or other agents over a trusted LAN.