### PR TITLE
Add AIImageChanger.app

### DIFF
--- a/data/aiimagechanger.yaml
+++ b/data/aiimagechanger.yaml
@@ -1,0 +1,3 @@
+name: AIImageChanger.app
+link: https://aiimagechanger.app/
+kind: Other


### PR DESCRIPTION
Adds AIImageChanger.app as a separate YAML data file, following the repository contribution instructions.

The entry uses only the canonical product URL and classifies the browser-based image editor under Other rather than mislabeling it as a text-to-image generator.

Disclosure: I am submitting this on behalf of the product team.