### PR TITLE
Add AISO Tools (data/aiso-tools.yaml)

### DIFF
--- a/data/aiso-tools.yaml
+++ b/data/aiso-tools.yaml
@@ -1,0 +1,3 @@
+name: AISO Tools
+link: https://aisotools.com
+kind: Search


### PR DESCRIPTION
Adds AISO Tools under `Search`, following the documented contribution route (a new YAML file in `data/`, not an edit to the generated README).

AISO Tools checks whether AI assistants — ChatGPT, Perplexity, Google AI Overviews — actually recommend a given product for a query, and reports the gaps that keep it from being cited. It sits alongside Genspark/Devv in the search family: those answer queries, this one measures how you show up in the answers.

```yaml
name: AISO Tools
link: https://aisotools.com
kind: Search
```

Link verified 200. Field set matches `data/genspark.yaml`; `creator` omitted as it is in most existing entries.