### PR TITLE
docs: add SandBase CLI

### DIFF
--- a/data/sandbase-cli.yaml
+++ b/data/sandbase-cli.yaml
@@ -1,0 +1,5 @@
+name: SandBase CLI
+link: https://github.com/sandbaseai/cli
+kind: Develop Tool
+creator: SandBase AI
+description: Open-source CLI and local MCP bridge for discovering and running AI models through one API.


### PR DESCRIPTION
Adds SandBase CLI to the Develop Tool resources using the repository's YAML contribution format.

- Canonical repository: https://github.com/sandbaseai/cli
- Open-source Apache-2.0 CLI and local MCP bridge
- Six MCP tools for discovering and running 2,000+ AI models through one API

Disclosure: I contribute to sandbaseai/cli. The description is concise and factual for maintainer review.