### PR TITLE
Add StudyArena to Other

### DIFF
--- a/data/studyarena.yaml
+++ b/data/studyarena.yaml
@@ -1,0 +1,3 @@
+name: StudyArena
+link: https://studyarena.com
+kind: Other


### PR DESCRIPTION
I've been building StudyArena, where students compare three AI answers without model names, vote, and then reveal which models answered. That comparison flow is free.

I'd like to add it under Other, which already includes a model arena. This adds data/studyarena.yaml using the same fields as that entry. I checked the canonical link, parsed the YAML and searched for existing listings and submissions. The README can be rendered by the existing generator after merge.
